### PR TITLE
Potential fix for code scanning alert no. 28: Missing CSRF middleware

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -12,7 +12,8 @@
     "mongoose": "^8.10.0",
     "multer": "^1.4.5-lts.1",
     "nanoid": "^5.1.0",
-    "nodemon": "^3.1.7"
+    "nodemon": "^3.1.7",
+    "lusca": "^1.7.0"
   },
   "scripts": {
     "start": "nodemon index.js"

--- a/api/server.js
+++ b/api/server.js
@@ -5,6 +5,7 @@ const cookieParser = require('cookie-parser');
 const path = require('path');
 const helmet = require('helmet');
 const rateLimit = require('express-rate-limit');
+const csrf = require('lusca').csrf;
 const connectDB = require('./config/db');
 
 const app = express();
@@ -87,7 +88,7 @@ app.use(cors(corsOptions));
 app.use(express.json());
 app.use(cookieParser());
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
-
+app.use(csrf());
 
 app.use((err, req, res, next) => {
     if (err instanceof SyntaxError) {


### PR DESCRIPTION
Potential fix for [https://github.com/harsSharma45/Sumrise/security/code-scanning/28](https://github.com/harsSharma45/Sumrise/security/code-scanning/28)

To fix the problem, we need to add CSRF protection middleware to the Express application. The best way to do this is by using a well-known middleware package such as `lusca`. This package provides easy-to-use CSRF protection that can be integrated into the existing middleware stack.

1. Install the `lusca` package.
2. Import the `lusca` package in the `api/server.js` file.
3. Add the CSRF middleware to the Express application before any state-changing routes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
